### PR TITLE
Use register request struct for agent registration

### DIFF
--- a/internal/agent/agent_comm.go
+++ b/internal/agent/agent_comm.go
@@ -19,8 +19,12 @@ func (a *Agent) Register() error {
 	uri := fmt.Sprintf("http://%s:%d/register", agent.ServerIP, agent.ServerPort)
 	var resp api.Message
 
-	// POST request with agent as body, writes response to resp
-	if err := api.DoPost(a.Client, uri, agent, &resp); err != nil {
+	req := api.RegisterRequest{
+		Agent: &agent,
+	}
+
+	// POST request with the register request as body, writes response to resp
+	if err := api.DoPost(a.Client, uri, req, &resp); err != nil {
 		return fmt.Errorf("Register: %w", err)
 	}
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -30,6 +30,11 @@ type Agent struct {
 	LastSeen         *time.Time    `json:"last_seen,omitempty"`
 }
 
+// RegisterRequest represents the request body for the /register endpoint
+type RegisterRequest struct {
+	Agent *Agent `json:"agent"`
+}
+
 // Defines the TaskType type (see below)
 type TaskType string
 
@@ -53,9 +58,9 @@ type Task struct {
 type Result struct {
 	ResultID   int `json:"result_id"`
 	Task       `json:"task"`
-	Output     string `json:"output"`
-	ReturnCode int    `json:"return_code"`
-	CreatedAt time.Time `json:"created_at"`
+	Output     string    `json:"output"`
+	ReturnCode int       `json:"return_code"`
+	CreatedAt  time.Time `json:"created_at"`
 }
 
 // GetAgentsResponse represents the response from the server on the /get-agents endpoint

--- a/internal/server/handlers_register.go
+++ b/internal/server/handlers_register.go
@@ -11,7 +11,7 @@ import (
 )
 
 // RegisterHandler handles the registration of an agent to the server
-// The /register endpoint expects an agent_id in a POST request
+// The /register endpoint expects a RegisterRequest in a POST body
 func (srv *Server) RegisterHandler(w http.ResponseWriter, r *http.Request) {
 	// Check that the HTTP method is POST. This is the only allowed method
 	if r.Method != http.MethodPost {
@@ -26,14 +26,21 @@ func (srv *Server) RegisterHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Declares a new Agent for decoding
-	var agent api.Agent
+	// Declares a new request for decoding
+	var registerReq api.RegisterRequest
 
-	// Decodes the JSON of the incoming request into the agent variable and checks for errors
-	if err := json.NewDecoder(r.Body).Decode(&agent); err != nil {
+	// Decodes the JSON of the incoming request into the register request and checks for errors
+	if err := json.NewDecoder(r.Body).Decode(&registerReq); err != nil {
 		http.Error(w, "Invalid JSON", http.StatusBadRequest)
 		return
 	}
+
+	if registerReq.Agent == nil {
+		http.Error(w, "Missing agent", http.StatusBadRequest)
+		return
+	}
+
+	agent := registerReq.Agent
 
 	// Validates that the agent ID is non-empty
 	if agent.ID == "" {
@@ -48,7 +55,7 @@ func (srv *Server) RegisterHandler(w http.ResponseWriter, r *http.Request) {
 	log.Printf("Registering agent with ID: %q\n", agent.ID)
 
 	// Convert the api.Agent to a storage.Agent
-	storageAgent := apiToStorageAgent(&agent)
+	storageAgent := apiToStorageAgent(agent)
 	// Attempt to register the agent with the db
 	if err := srv.storage.RegisterAgent(storageAgent); err != nil {
 		log.Printf("RegisterAgent failed for %s: %v\n", agent.ID, err)


### PR DESCRIPTION
## Summary
- add a dedicated `RegisterRequest` type to the API definitions
- update the agent registration client to send the new request payload
- adjust the server `/register` handler to decode and validate the explicit request structure

## Testing
- `GOPROXY=off go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68cf3c528bf88330989a131d6199e03f